### PR TITLE
FIX yew specific characters makes invalid HTML

### DIFF
--- a/client/src/embeddedHTML.ts
+++ b/client/src/embeddedHTML.ts
@@ -44,6 +44,9 @@ export function getHTMLVirtualContent(documentText: string) {
 	content = content.replace(/<>/g, '  ');
 	content = content.replace(/<\/>/g, '   ');
 	content = content.replace(/<.*\/>/g, "");
+	content = content.replace(/=|~/g, ' ');
+	content = content.replace(/@/g, 'g');
+
 	return content;
 }
 


### PR DESCRIPTION
Right now `@` dynamic tag will take the value of `g` as it doesn't have any HTML meaning so hovering would not show up. However, we should look into query rust-analyzer if we can. 

FIX #4